### PR TITLE
Fixed bug when ia_model = IANone

### DIFF
--- a/ClLike/cl_like/cl_final.py
+++ b/ClLike/cl_like/cl_final.py
@@ -175,9 +175,10 @@ class ClFinal(Theory):
                     pn = '_'.join([self.input_params_prefix, survey, 'A_IA'])
                     if pn in bias_names:
                         continue
-                bias_names.append(pn)
-                bd['bias_ind'] = [ind_bias]
-                ind_bias += 1
+                if ia_model != 'IANone':
+                    bias_names.append(pn)
+                    bd['bias_ind'] = [ind_bias]
+                    ind_bias += 1
             elif quantity == 'cmb_convergence':
                 bd['eps'] = True
 


### PR DESCRIPTION
I just put an if statement in front of some of the parameters that should be defined only if there is a bias model. The code works, check if it is elegant enough