### PR TITLE
Added method to get the data sacc file

### DIFF
--- a/ClLike/cl_like/cl_like.py
+++ b/ClLike/cl_like/cl_like.py
@@ -168,6 +168,8 @@ class ClLike(Likelihood):
         # Invert covariance
         self.inv_cov = self.get_inv_cov(self.cov)
         self.ndata = len(self.data_vec)
+        # Keep indices in case we want so slice the original sacc file
+        self.indices = indices
 
     def get_inv_cov(self, cov):
         if self.null_negative_cov_eigvals_in_icov:
@@ -246,6 +248,18 @@ class ClLike(Likelihood):
 
         return s
 
+    def get_cl_data_sacc(self):
+        s = self.sacc_file.copy()
+        s.keep_indices(self.indices)
+
+        tracers = []
+        for trs in s.get_tracer_combinations():
+            tracers.extend(trs)
+
+        # Use list(set()) to remove duplicates
+        s.keep_tracers(list(set(tracers)))
+
+        return s
 
 
 class ClLikeFastBias(ClLike):

--- a/ClLike/cl_like/tests/test_bias_models.py
+++ b/ClLike/cl_like/tests/test_bias_models.py
@@ -213,3 +213,19 @@ def test_get_theory_cl_sacc():
         if tr.quantity == 'cmb_lensing':
             assert tr.spin == 0
 
+
+def test_get_cl_data_sacc():
+    info = get_info('Linear')
+
+    model = get_model(info)
+    loglikes, derived = model.loglikes()
+    lkl = model.likelihood['ClLike']
+
+    s = lkl.get_cl_data_sacc()
+    assert s.mean.size == lkl.ndata
+    indices = []
+    for clm in lkl.cl_meta:
+        indices.extend(list(s.indices(tracers=(clm['bin_1'], clm['bin_2']))))
+    s.reorder(indices)
+    assert s.mean == pytest.approx(lkl.data_vec, rel=1e-5)
+    assert np.all(s.covariance.covmat == lkl.cov)


### PR DESCRIPTION
I have added a method to get the data used in a sacc file, that way one does not need to apply scale cuts, etc, in case one wants to plot. (One could use `cl_meta`, but I find sacc files more convenient)