### PR TITLE
baccoemu: fix matter pk when ignore_lbias=True

### DIFF
--- a/ClLike/cl_like/power_spectrum.py
+++ b/ClLike/cl_like/power_spectrum.py
@@ -225,7 +225,8 @@ class Pk(Theory):
                     if op1 != op2:
                         comb_21 = op2+op1
                         pkd[f'pk_{comb_21}'] = pkd[f'pk_{comb_12}']
-            if (self.bias_model == 'BaccoPT') and self.use_baryon_boost:
+            if (self.bias_model == 'BaccoPT') and \
+                (self.use_baryon_boost or self.ignore_lbias):
                 # TODO: This assumes LCDM, but as above. BACCOemu is trained
                 # only in LCDM, anyway. What to do with the cross pk's? At the
                 # moment they don't have the correction.


### PR DESCRIPTION
This fixes the case when `ignore_bias=True` and no baryonic corrections requested. In this case, before this fix, one would get the pk nonlinear from CCL; i.e. halofit, normally.

Should I add a test?