### PR TITLE
add informative message if requested duplicated tracer pairs

### DIFF
--- a/ClLike/cl_like/bacco.py
+++ b/ClLike/cl_like/bacco.py
@@ -19,6 +19,7 @@ class BaccoCalculator(object):
     def __init__(self, log10k_min=np.log10(0.008), log10k_max=np.log10(0.5), nk_per_decade=20,
                  log10k_sh_sh_min=np.log10(0.0001), log10k_sh_sh_max=np.log10(50), nk_sh_sh_per_decade=20,
                  a_arr=None, nonlinear_emu_path=None, nonlinear_emu_details=None, use_baryon_boost=False,
+                 nonlinear_model_name=None,
                  ignore_lbias=False, allow_bcm_emu_extrapolation_for_shear=True,
                  allow_halofit_extrapolation_for_shear=False,
                  allow_halofit_extrapolation_for_shear_on_k=False):
@@ -36,7 +37,8 @@ class BaccoCalculator(object):
             warnings.filterwarnings('ignore', category=UserWarning)
             self.lbias = baccoemu.Lbias_expansion()
             self.mpk = baccoemu.Matter_powerspectrum(nonlinear_emu_path=nonlinear_emu_path,
-                                                     nonlinear_emu_details=nonlinear_emu_details)
+                                                     nonlinear_emu_details=nonlinear_emu_details,
+                                                     nonlinear_model_name=nonlinear_model_name)
 
         # check with the currently loaded version of baccoemu if the a array is
         # all within the allowed ranges

--- a/ClLike/cl_like/cl_like.py
+++ b/ClLike/cl_like/cl_like.py
@@ -169,6 +169,13 @@ class ClLike(Likelihood):
             indices += list(ind)
             id_sofar += c_ell.size
         indices = np.array(indices)
+        # Check that we have not duplicated indices
+        if len(indices) != len(set(indices)):
+            raise LoggedError(self.log,
+                              "Some data points have been included more "
+                              "than once in the data vector. Please check "
+                              "your scale cuts and two-point function "
+                              "definitions.")
         # Reorder data vector and covariance
         self.data_vec = s.mean[indices]
         self.cov = s.covariance.dense[indices][:, indices]

--- a/ClLike/cl_like/limber.py
+++ b/ClLike/cl_like/limber.py
@@ -27,6 +27,9 @@ class Limber(Theory):
     # Magnification bias selected per tracer in defaults
     # with_magnification_bias: bool = False
 
+    # Limber integral?
+    angular_cl_kwargs: dict = {}
+
     def initialize(self):
         self.cl_meta = None
         self.l_sample = None
@@ -183,7 +186,7 @@ class Limber(Theory):
             # 00: unbiased x unbiased
             if t0_1 and t0_2:
                 pk = pkd[f'pk_{t0dn_1}{t0dn_2}']
-                cl00 = ccl.angular_cl(cosmo, t0_1, t0_2, ls, p_of_k_a=pk) * clm['pixbeam']
+                cl00 = ccl.angular_cl(cosmo, t0_1, t0_2, ls, p_of_k_a=pk, **self.angular_cl_kwargs) * clm['pixbeam']
                 cls_00.append(cl00)
             else:
                 cls_00.append(None)
@@ -193,7 +196,7 @@ class Limber(Theory):
                 for t12, dn in zip(t1_2, t1dn_2):
                     pk = pkd[f'pk_{t0dn_1}{dn}']
                     if pk is not None:
-                        cl = ccl.angular_cl(cosmo, t0_1, t12, ls, p_of_k_a=pk) * clm['pixbeam']
+                        cl = ccl.angular_cl(cosmo, t0_1, t12, ls, p_of_k_a=pk, **self.angular_cl_kwargs) * clm['pixbeam']
                     else:
                         cl = np.zeros_like(ls)
                     cl01.append(cl)
@@ -210,7 +213,7 @@ class Limber(Theory):
                     for t11, dn in zip(t1_1, t1dn_1):
                         pk = pkd[f'pk_{t0dn_2}{dn}']
                         if pk is not None:
-                            cl = ccl.angular_cl(cosmo, t11, t0_2, ls, p_of_k_a=pk) * clm['pixbeam']
+                            cl = ccl.angular_cl(cosmo, t11, t0_2, ls, p_of_k_a=pk, **self.angular_cl_kwargs) * clm['pixbeam']
                         else:
                             cl = np.zeros_like(ls)
                         cl10.append(cl)
@@ -229,7 +232,7 @@ class Limber(Theory):
                         else:
                             pk = pkd[f'pk_{dn1}{dn2}']
                             if pk is not None:
-                                cl = ccl.angular_cl(cosmo, t11, t12, ls, p_of_k_a=pk) * clm['pixbeam']
+                                cl = ccl.angular_cl(cosmo, t11, t12, ls, p_of_k_a=pk, **self.angular_cl_kwargs) * clm['pixbeam']
                             else:
                                 cl = np.zeros_like(ls)
                             cl11[i1, i2, :] = cl

--- a/ClLike/cl_like/power_spectrum.py
+++ b/ClLike/cl_like/power_spectrum.py
@@ -52,6 +52,7 @@ class Pk(Theory):
     #for baccoemu
     nonlinear_emu_path = None
     nonlinear_emu_details = None
+    nonlinear_model_name = None
     use_baryon_boost : bool = False
     baryon_model: str = ''
     ignore_lbias : bool = False
@@ -124,6 +125,7 @@ class Pk(Theory):
             self.bacco_calc = BaccoCalculator(a_arr=self.a_s_pks,
                                               nonlinear_emu_path=self.nonlinear_emu_path,
                                               nonlinear_emu_details=self.nonlinear_emu_details,
+                                              nonlinear_model_name=self.nonlinear_model_name,
                                               use_baryon_boost=use_baryon_boost,
                                               ignore_lbias=self.ignore_lbias,
                                               allow_bcm_emu_extrapolation_for_shear=self.allow_bcm_emu_extrapolation_for_shear,

--- a/ClLike/cl_like/tests/test_bias_models.py
+++ b/ClLike/cl_like/tests/test_bias_models.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import sacc
 from cobaya import run
+from cobaya.log import LoggedError
 
 
 OUTDIR = 'dum'
@@ -431,3 +432,15 @@ def test_camb_hmcode_dum(case):
 
 
     assert np.abs(loglikes[0] / loglikes2[0] - 1) < 1e-5
+
+
+def test_duplicated_data_points_error():
+    info = get_info('Linear')
+
+    # Adding duplicated data points
+    info['likelihood']['ClLike']['twopoints'].append(
+        {"bins": ["gc0", "sh0"]}
+    )
+
+    with pytest.raises(LoggedError):
+        get_model(info)


### PR DESCRIPTION
Add an informative error message when the user has added the same tracer pairs multiple times.